### PR TITLE
feat: add production Dockerfile

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,26 @@
+# Use node:18-alpine base image
+FROM node:18-alpine
+
+# Set the working directory inside the container
+WORKDIR /app
+
+# Copy dependency files
+COPY package.json package-lock.json ./
+
+# Install dependencies
+RUN npm ci
+
+# Copy the rest of the application code
+COPY . .
+
+# Build the application
+RUN npm run build
+
+# Expose the port the app runs on
+EXPOSE 9000
+
+# Set production environment
+ENV NODE_ENV=production
+
+# Start the application
+CMD ["npm", "start"]


### PR DESCRIPTION
## Summary
- add Dockerfile for building and running the app in production

## Testing
- `npm test` *(fails: Module svelte-jester in the transform option was not found)*
- `npm run lint`
- `npm run build`


