### PR TITLE
Add root Dockerfile and compose service

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,13 @@
+# Build stage
+FROM node:18 AS build
+WORKDIR /app
+COPY package*.json ./
+RUN npm ci
+COPY . .
+RUN npm run build
+
+# Production stage
+FROM nginx:alpine
+COPY --from=build /app/dist /usr/share/nginx/html
+EXPOSE 80
+CMD ["nginx", "-g", "daemon off;"]

--- a/angular-app/Dockerfile
+++ b/angular-app/Dockerfile
@@ -1,0 +1,13 @@
+# Build stage
+FROM node:18 AS build
+WORKDIR /app
+COPY package*.json ./
+RUN npm ci
+COPY . .
+RUN npm run build
+
+# Production stage
+FROM nginx:alpine
+COPY --from=build /app/dist/angular-app /usr/share/nginx/html
+EXPOSE 80
+CMD ["nginx", "-g", "daemon off;"]

--- a/dashboard/Dockerfile
+++ b/dashboard/Dockerfile
@@ -1,0 +1,13 @@
+# Build stage
+FROM node:18 AS build
+WORKDIR /app
+COPY package*.json ./
+RUN npm ci
+COPY . .
+RUN npm run build
+
+# Production stage
+FROM nginx:alpine
+COPY --from=build /app/dist/dashboard /usr/share/nginx/html
+EXPOSE 80
+CMD ["nginx", "-g", "daemon off;"]

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,0 +1,22 @@
+version: '3.8'
+services:
+  root-config:
+    build: .
+    ports:
+      - "9000:80"
+  dashboard:
+    build: ./dashboard
+    ports:
+      - "8080:80"
+  react-app:
+    build: ./react-app
+    ports:
+      - "8081:80"
+  angular-app:
+    build: ./angular-app
+    ports:
+      - "8082:80"
+  python-backend:
+    build: ./python-backend
+    ports:
+      - "8000:8000"

--- a/python-backend/Dockerfile
+++ b/python-backend/Dockerfile
@@ -1,0 +1,7 @@
+FROM python:3.11-slim
+WORKDIR /app
+COPY requirements.txt .
+RUN pip install --no-cache-dir -r requirements.txt
+COPY app ./app
+EXPOSE 8000
+CMD ["uvicorn", "app.main:app", "--host", "0.0.0.0", "--port", "8000"]

--- a/react-app/Dockerfile
+++ b/react-app/Dockerfile
@@ -1,0 +1,13 @@
+# Build stage
+FROM node:18 AS build
+WORKDIR /app
+COPY package*.json ./
+RUN npm ci
+COPY . .
+RUN npm run build
+
+# Production stage
+FROM nginx:alpine
+COPY --from=build /app/dist /usr/share/nginx/html
+EXPOSE 80
+CMD ["nginx", "-g", "daemon off;"]


### PR DESCRIPTION
## Summary
- add multi-stage Dockerfile for root config build
- expose root-config service via docker-compose

## Testing
- `npm test` *(fails: Module svelte-jester in the transform option was not found)*
- `cd python-backend && python -m py_compile app/main.py`


------
https://chatgpt.com/codex/tasks/task_e_68a5359988288331a09d2298c003a4bd