### PR TITLE
feat: add postgres service with pgvector

### DIFF
--- a/docker-compose.dev.yml
+++ b/docker-compose.dev.yml
@@ -1,4 +1,20 @@
 services:
+  postgres:
+    image: pgvector/pgvector:pg16
+    ports:
+      - "5432:5432"
+    environment:
+      POSTGRES_DB: ragdb
+      POSTGRES_USER: raguser
+      POSTGRES_PASSWORD: ragpassword
+    volumes:
+      - postgres-data:/var/lib/postgresql/data
+    healthcheck:
+      test: ["CMD-SHELL", "pg_isready -U $$POSTGRES_USER"]
+      interval: 5s
+      timeout: 5s
+      retries: 5
+
   root-config:
     build: .
     ports: ["9000:9000"]
@@ -21,7 +37,13 @@ services:
     volumes:
       - ./python-backend/app:/app/app
     command: uvicorn app.main:app --host 0.0.0.0 --port 8000 --reload
+    depends_on:
+      postgres:
+        condition: service_healthy
     ports: ["8000:8000"]
 
 
-    #docker compose -f docker-compose.dev.yml up` for development with live reload
+      #docker compose -f docker-compose.dev.yml up` for development with live reload
+
+volumes:
+  postgres-data:

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,4 +1,20 @@
 services:
+  postgres:
+    image: pgvector/pgvector:pg16
+    ports:
+      - "5432:5432"
+    environment:
+      POSTGRES_DB: ragdb
+      POSTGRES_USER: raguser
+      POSTGRES_PASSWORD: ragpassword
+    volumes:
+      - postgres-data:/var/lib/postgresql/data
+    healthcheck:
+      test: ["CMD-SHELL", "pg_isready -U $$POSTGRES_USER"]
+      interval: 5s
+      timeout: 5s
+      retries: 5
+
   root-config:
     build: .
     ports: ["9000:9000"]
@@ -17,5 +33,11 @@ services:
 
   backend:
     build: ./python-backend
-    env_file: ./python-backend/app/.env   
+    env_file: ./python-backend/app/.env
+    depends_on:
+      postgres:
+        condition: service_healthy
     ports: ["8000:8000"]
+
+volumes:
+  postgres-data:


### PR DESCRIPTION
## Summary
- add postgres service with pgvector image and persistent storage
- ensure backend waits for postgres readiness

## Testing
- `npm test`
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_68ae4a3c065883319655faa4e2c654d3