### PR TITLE
Use PostgreSQL for authentication and setup pgvector

### DIFF
--- a/python-backend/app/database.py
+++ b/python-backend/app/database.py
@@ -1,0 +1,24 @@
+import os
+from sqlalchemy import create_engine, text
+from sqlalchemy.orm import sessionmaker, declarative_base
+
+DATABASE_URL = os.getenv("DATABASE_URL", "postgresql://raguser:ragpassword@postgres:5432/ragdb")
+
+engine = create_engine(DATABASE_URL)
+SessionLocal = sessionmaker(autocommit=False, autoflush=False, bind=engine)
+Base = declarative_base()
+
+
+def init_db():
+    """Create database tables and ensure pgvector extension."""
+    with engine.connect() as conn:
+        conn.execute(text("CREATE EXTENSION IF NOT EXISTS vector"))
+    Base.metadata.create_all(bind=engine)
+
+
+def get_db():
+    db = SessionLocal()
+    try:
+        yield db
+    finally:
+        db.close()

--- a/python-backend/app/models.py
+++ b/python-backend/app/models.py
@@ -1,0 +1,20 @@
+from sqlalchemy import Column, Integer, String
+from pgvector.sqlalchemy import Vector
+
+from .database import Base
+
+
+class User(Base):
+    __tablename__ = "users"
+
+    id = Column(Integer, primary_key=True, index=True)
+    username = Column(String, unique=True, index=True, nullable=False)
+    hashed_password = Column(String, nullable=False)
+
+
+class Document(Base):
+    __tablename__ = "documents"
+
+    id = Column(Integer, primary_key=True, index=True)
+    content = Column(String)
+    embedding = Column(Vector(1536))

--- a/python-backend/requirements.txt
+++ b/python-backend/requirements.txt
@@ -7,3 +7,4 @@ python-multipart
 psycopg2-binary
 SQLAlchemy
 pgvector
+


### PR DESCRIPTION
## Summary
- replace in-memory auth with PostgreSQL using SQLAlchemy
- initialize pgvector extension and add example document model

## Testing
- `python -m py_compile python-backend/app/database.py python-backend/app/models.py python-backend/app/main.py`
- `pip install -r python-backend/requirements.txt` *(fails: Tunnel connection failed: 403 Forbidden)*

------
https://chatgpt.com/codex/tasks/task_e_68ae4f8f0e988331bcfb0449fee174b1