### PR TITLE
Add MinIO service and usage example

### DIFF
--- a/README.md
+++ b/README.md
@@ -82,7 +82,23 @@ A platform for uploading and querying academic or reference materials conversati
   * admin: 8002
   * postgres: 5432
   * redis: 6379
-  * minio: 9000 (console 9001)
+  * minio: 9001 (console 9002)
+
+---
+
+### MinIO example
+
+An example script demonstrating basic interaction with MinIO is provided at
+`python-backend/examples/minio_example.py`. After starting the services with
+Docker Compose, run:
+
+```bash
+pip install -r python-backend/requirements.txt
+python python-backend/examples/minio_example.py
+```
+
+The script connects to `localhost:9001`, creates a bucket, uploads a file, and
+prints its contents.
 
 ---
 

--- a/docker-compose.dev.yml
+++ b/docker-compose.dev.yml
@@ -43,8 +43,21 @@ services:
         condition: service_healthy
     ports: ["8000:8000"]
 
+  minio:
+    image: minio/minio
+    ports:
+      - "9001:9000"
+      - "9002:9001"
+    environment:
+      MINIO_ROOT_USER: minioadmin
+      MINIO_ROOT_PASSWORD: minioadmin
+    command: server /data --console-address ":9001"
+    volumes:
+      - minio-data:/data
+
 
       #docker compose -f docker-compose.dev.yml up` for development with live reload
 
 volumes:
   postgres-data:
+  minio-data:

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -40,5 +40,18 @@ services:
         condition: service_healthy
     ports: ["8000:8000"]
 
+  minio:
+    image: minio/minio
+    ports:
+      - "9001:9000"
+      - "9002:9001"
+    environment:
+      MINIO_ROOT_USER: minioadmin
+      MINIO_ROOT_PASSWORD: minioadmin
+    command: server /data --console-address ":9001"
+    volumes:
+      - minio-data:/data
+
 volumes:
   postgres-data:
+  minio-data:

--- a/python-backend/examples/minio_example.py
+++ b/python-backend/examples/minio_example.py
@@ -1,0 +1,25 @@
+from io import BytesIO
+from minio import Minio
+
+# Connect to the local MinIO server running via docker compose
+client = Minio(
+    "localhost:9001",
+    access_key="minioadmin",
+    secret_key="minioadmin",
+    secure=False,
+)
+
+bucket = "demo"
+if not client.bucket_exists(bucket):
+    client.make_bucket(bucket)
+
+# Upload a small text file from memory
+content = BytesIO(b"Hello from MinIO!")
+client.put_object(bucket, "hello.txt", content, length=content.getbuffer().nbytes)
+
+# Retrieve the object and print its contents
+response = client.get_object(bucket, "hello.txt")
+print(response.read().decode())
+response.close()
+response.release_conn()
+

--- a/python-backend/requirements.txt
+++ b/python-backend/requirements.txt
@@ -7,3 +7,4 @@ python-multipart
 psycopg2-binary
 SQLAlchemy
 pgvector
+minio


### PR DESCRIPTION
## Summary
- Add MinIO service to docker compose using ports 9001/9002 and persistent volume
- Document and demonstrate MinIO usage with example Python script
- Include MinIO client dependency for backend

## Testing
- `npm test`
- `pytest`


------
https://chatgpt.com/codex/tasks/task_e_68b735d6bc348331be1f968378097974