### PR TITLE
Refactor Python backend into MVC structure

### DIFF
--- a/python-backend/app/__init__.py
+++ b/python-backend/app/__init__.py
@@ -1,0 +1,5 @@
+"""Expose the FastAPI application instance for ASGI servers."""
+
+from .main import app
+
+__all__ = ["app"]

--- a/python-backend/app/controllers/__init__.py
+++ b/python-backend/app/controllers/__init__.py
@@ -1,0 +1,16 @@
+"""FastAPI routers grouped by feature area."""
+
+from fastapi import APIRouter
+
+from .auth_controller import router as auth_router
+from .embedding_controller import router as embedding_router
+from .image_controller import router as image_router
+from .system_controller import router as system_router
+
+api_router = APIRouter()
+api_router.include_router(system_router)
+api_router.include_router(auth_router)
+api_router.include_router(embedding_router)
+api_router.include_router(image_router)
+
+__all__ = ["api_router"]

--- a/python-backend/app/controllers/auth_controller.py
+++ b/python-backend/app/controllers/auth_controller.py
@@ -1,0 +1,41 @@
+"""Authentication related API endpoints."""
+
+from fastapi import APIRouter, Depends, HTTPException
+from fastapi.security import OAuth2PasswordRequestForm
+from sqlalchemy.orm import Session
+
+from ..core.config import ACCESS_TOKEN_EXPIRE_DELTA
+from ..core.security import (
+    authenticate_user,
+    create_access_token,
+    get_current_username,
+)
+from ..db import get_db
+from ..views.schemas import Token
+
+router = APIRouter(prefix="/api", tags=["auth"])
+
+
+@router.post("/login", response_model=Token)
+async def login(
+    form_data: OAuth2PasswordRequestForm = Depends(),
+    db: Session = Depends(get_db),
+):
+    """Authenticate a user and issue a JWT access token."""
+
+    user = authenticate_user(db, form_data.username, form_data.password)
+    if not user:
+        raise HTTPException(status_code=400, detail="Incorrect username or password")
+
+    access_token = create_access_token(
+        data={"sub": user.username},
+        expires_delta=ACCESS_TOKEN_EXPIRE_DELTA,
+    )
+    return {"access_token": access_token, "token_type": "bearer"}
+
+
+@router.get("/protected")
+async def protected_route(username: str = Depends(get_current_username)):
+    """Return a simple message for authenticated users."""
+
+    return {"message": f"Hello, {username}"}

--- a/python-backend/app/controllers/embedding_controller.py
+++ b/python-backend/app/controllers/embedding_controller.py
@@ -1,0 +1,40 @@
+"""Embedding related API endpoints."""
+
+from typing import List
+
+from fastapi import APIRouter, Depends, Query
+from sqlalchemy.orm import Session
+
+from ..db import get_db
+from ..models import Embedding
+from ..views.schemas import EmbeddingOut
+from ..views.transformers import embedding_to_out
+
+router = APIRouter(prefix="/api/embeddings", tags=["embeddings"])
+
+
+@router.post("/demo", response_model=EmbeddingOut)
+def create_demo_embedding(db: Session = Depends(get_db)):
+    """Persist a demo embedding and return it."""
+
+    vector = [0.1, 0.2, 0.3]
+    embedding = Embedding(embedding=vector, content="demo content")
+    db.add(embedding)
+    db.commit()
+    db.refresh(embedding)
+    return embedding_to_out(embedding)
+
+
+@router.get("/demo", response_model=List[EmbeddingOut])
+def list_embeddings(
+    vector: List[float] = Query(...),
+    db: Session = Depends(get_db),
+):
+    """Return embeddings ordered by distance to the provided vector."""
+
+    results = (
+        db.query(Embedding)
+        .order_by(Embedding.embedding.cosine_distance(vector))
+        .all()
+    )
+    return [embedding_to_out(result) for result in results]

--- a/python-backend/app/controllers/image_controller.py
+++ b/python-backend/app/controllers/image_controller.py
@@ -1,0 +1,81 @@
+"""Image upload and processing endpoints."""
+
+import hashlib
+import uuid
+from io import BytesIO
+from typing import List, Optional
+
+import numpy as np
+from fastapi import APIRouter, Depends, File, HTTPException, UploadFile
+from PIL import Image
+from sqlalchemy.orm import Session
+
+from ..core.clients import clip_model, minio_client, ocr_reader
+from ..core.config import MINIO_BUCKET, MINIO_ENDPOINT, MINIO_SECURE
+from ..db import get_db
+from ..models import ImageMetadata
+from ..views.schemas import ImageOut
+from ..views.transformers import image_to_out
+
+router = APIRouter(prefix="/api", tags=["images"])
+
+
+@router.post("/upload-image", response_model=ImageOut)
+async def upload_image(
+    file: UploadFile = File(...),
+    db: Session = Depends(get_db),
+):
+    """Store an uploaded image, persist its metadata and return the record."""
+
+    data = await file.read()
+    if not data:
+        raise HTTPException(status_code=400, detail="Uploaded file is empty")
+
+    object_name = f"{uuid.uuid4()}_{file.filename}"
+    minio_client.put_object(
+        MINIO_BUCKET,
+        object_name,
+        BytesIO(data),
+        length=len(data),
+        content_type=file.content_type,
+    )
+
+    image = Image.open(BytesIO(data)).convert("RGB")
+    width, height = image.size
+    hash_value = hashlib.sha256(data).hexdigest()
+    scheme = "https" if MINIO_SECURE else "http"
+    url = f"{scheme}://{MINIO_ENDPOINT}/{MINIO_BUCKET}/{object_name}"
+
+    image_embedding_vector = (
+        clip_model.encode([image], convert_to_tensor=False)[0].tolist()
+    )
+
+    ocr_text: Optional[str] = None
+    text_embedding_vector: Optional[List[float]] = None
+    try:
+        ocr_results = ocr_reader.readtext(np.array(image), detail=0)
+        text_parts = [result for result in ocr_results if result]
+        if text_parts:
+            ocr_text = " ".join(text_parts).strip()
+    except Exception:  # pragma: no cover - protective fallback
+        ocr_text = None
+
+    if ocr_text:
+        text_embedding_vector = (
+            clip_model.encode([ocr_text], convert_to_tensor=False)[0].tolist()
+        )
+
+    metadata = ImageMetadata(
+        url=url,
+        hash=hash_value,
+        width=width,
+        height=height,
+        embedding=image_embedding_vector,
+        text=ocr_text,
+        text_embedding=text_embedding_vector,
+    )
+    db.add(metadata)
+    db.commit()
+    db.refresh(metadata)
+
+    return image_to_out(metadata)

--- a/python-backend/app/controllers/system_controller.py
+++ b/python-backend/app/controllers/system_controller.py
@@ -1,0 +1,36 @@
+"""Miscellaneous application endpoints."""
+
+import requests
+from fastapi import APIRouter, HTTPException
+
+from ..core.config import OPENAI_API_KEY, OPENAI_API_URL
+from ..views.schemas import OpenAIRequest
+
+router = APIRouter(prefix="/api", tags=["system"])
+
+
+@router.get("/hello")
+async def read_hello():
+    """Return a simple greeting used for health checks."""
+
+    return {"message": "Hello from FastAPI"}
+
+
+@router.post("/openai")
+def call_openai(request: OpenAIRequest):
+    """Proxy a request to the OpenAI responses endpoint."""
+
+    api_key = OPENAI_API_KEY
+    if not api_key:
+        raise HTTPException(status_code=500, detail="OPENAI_API_KEY not set")
+
+    headers = {
+        "Authorization": f"Bearer {api_key}",
+        "Content-Type": "application/json",
+    }
+    payload = {"model": request.model, "input": request.input}
+
+    response = requests.post(OPENAI_API_URL, headers=headers, json=payload)
+    if response.status_code != 200:
+        raise HTTPException(status_code=response.status_code, detail=response.text)
+    return response.json()

--- a/python-backend/app/core/clients.py
+++ b/python-backend/app/core/clients.py
@@ -1,0 +1,24 @@
+"""Shared external service clients and heavy resources."""
+
+import easyocr
+from minio import Minio
+from sentence_transformers import SentenceTransformer
+
+from .config import (
+    MINIO_ACCESS_KEY,
+    MINIO_ENDPOINT,
+    MINIO_SECRET_KEY,
+    MINIO_SECURE,
+)
+
+minio_client = Minio(
+    MINIO_ENDPOINT,
+    access_key=MINIO_ACCESS_KEY,
+    secret_key=MINIO_SECRET_KEY,
+    secure=MINIO_SECURE,
+)
+
+clip_model = SentenceTransformer("clip-ViT-B-32")
+ocr_reader = easyocr.Reader(["en"], gpu=False)
+
+__all__ = ["clip_model", "minio_client", "ocr_reader"]

--- a/python-backend/app/core/config.py
+++ b/python-backend/app/core/config.py
@@ -1,0 +1,30 @@
+"""Central configuration for the FastAPI backend."""
+
+import os
+from datetime import timedelta
+from typing import List
+
+from dotenv import load_dotenv
+
+load_dotenv()
+
+JWT_SECRET = os.getenv("JWT_SECRET")
+ALGORITHM = "HS256"
+ACCESS_TOKEN_EXPIRE_MINUTES = int(os.getenv("ACCESS_TOKEN_EXPIRE_MINUTES", "30"))
+ACCESS_TOKEN_EXPIRE_DELTA = timedelta(minutes=ACCESS_TOKEN_EXPIRE_MINUTES)
+
+MINIO_ENDPOINT = os.getenv("MINIO_ENDPOINT", "localhost:9001")
+MINIO_ACCESS_KEY = os.getenv("MINIO_ACCESS_KEY", "minioadmin")
+MINIO_SECRET_KEY = os.getenv("MINIO_SECRET_KEY", "minioadmin")
+MINIO_BUCKET = os.getenv("MINIO_BUCKET", "images")
+MINIO_SECURE = os.getenv("MINIO_SECURE", "false").lower() == "true"
+
+OPENAI_API_KEY = os.getenv("OPENAI_API_KEY")
+OPENAI_API_URL = os.getenv("OPENAI_API_URL", "https://api.openai.com/v1/responses")
+
+CORS_ORIGINS: List[str] = [
+    "http://localhost:9000",
+    "http://localhost:4200",
+    "http://localhost:4201",
+    "http://localhost:8080",
+]

--- a/python-backend/app/core/security.py
+++ b/python-backend/app/core/security.py
@@ -1,0 +1,62 @@
+"""Authentication helpers and shared security utilities."""
+
+from datetime import datetime, timedelta
+from typing import Optional
+
+from fastapi import Depends, HTTPException
+from fastapi.security import OAuth2PasswordBearer
+from jose import JWTError, jwt
+from passlib.context import CryptContext
+from sqlalchemy.orm import Session
+from ..models import User
+from .config import ACCESS_TOKEN_EXPIRE_MINUTES, ALGORITHM, JWT_SECRET
+
+pwd_context = CryptContext(schemes=["argon2"], deprecated="auto")
+oauth2_scheme = OAuth2PasswordBearer(tokenUrl="/api/login")
+
+
+def authenticate_user(db: Session, username: str, password: str) -> Optional[User]:
+    """Validate the supplied credentials and return the user if valid."""
+
+    user = db.query(User).filter(User.username == username).first()
+    if not user:
+        return None
+    if not pwd_context.verify(password, user.hashed_password):
+        return None
+    return user
+
+
+def create_access_token(data: dict, expires_delta: Optional[timedelta] = None) -> str:
+    """Create a signed JWT token for the supplied payload."""
+
+    if not JWT_SECRET:
+        raise RuntimeError("JWT_SECRET environment variable is not set")
+
+    to_encode = data.copy()
+    expire = datetime.utcnow() + (
+        expires_delta or timedelta(minutes=ACCESS_TOKEN_EXPIRE_MINUTES)
+    )
+    to_encode.update({"exp": expire})
+    return jwt.encode(to_encode, JWT_SECRET, algorithm=ALGORITHM)
+
+
+def get_username_from_token(token: str) -> str:
+    """Extract the username from a JWT token, raising if invalid."""
+
+    if not JWT_SECRET:
+        raise HTTPException(status_code=500, detail="JWT secret is not configured")
+
+    try:
+        payload = jwt.decode(token, JWT_SECRET, algorithms=[ALGORITHM])
+        username: Optional[str] = payload.get("sub")
+        if username is None:
+            raise HTTPException(status_code=401, detail="Invalid token")
+        return username
+    except JWTError as exc:  # pragma: no cover - defensive branch
+        raise HTTPException(status_code=401, detail="Invalid token") from exc
+
+
+def get_current_username(token: str = Depends(oauth2_scheme)) -> str:
+    """FastAPI dependency that returns the username for the supplied token."""
+
+    return get_username_from_token(token)

--- a/python-backend/app/main.py
+++ b/python-backend/app/main.py
@@ -1,84 +1,34 @@
-from datetime import datetime, timedelta
-from typing import List, Optional
-import requests
-import hashlib
-import numpy as np
-import easyocr
+"""Application entry-point exposing the FastAPI instance."""
 
-from fastapi import Depends, FastAPI, HTTPException, Query, UploadFile, File
+from fastapi import FastAPI
 from fastapi.middleware.cors import CORSMiddleware
-from fastapi.security import OAuth2PasswordBearer, OAuth2PasswordRequestForm
-from jose import JWTError, jwt
-from passlib.context import CryptContext
-from dotenv import load_dotenv
 from sqlalchemy import inspect, text as sa_text
 from sqlalchemy.exc import NoSuchTableError
-from sqlalchemy.orm import Session
-import os
-from langchain_openai import ChatOpenAI, OpenAIEmbeddings
-from minio import Minio
-from io import BytesIO
-import uuid
-from PIL import Image
-from sentence_transformers import SentenceTransformer
 
-from .db import Base, engine, SessionLocal, get_db
-from .models import Embedding, User, ImageMetadata
-from .schemas import (
-    OpenAIRequest,
-    Token,
-    EmbeddingOut,
-    AskRequest,
-    AskResponse,
-    ImageOut,
-)
-
-# Load environment variables
-load_dotenv()
-JWT_SECRET = os.getenv("JWT_SECRET")
-ALGORITHM = "HS256"
-ACCESS_TOKEN_EXPIRE_MINUTES = 30
-
-MINIO_ENDPOINT = os.getenv("MINIO_ENDPOINT", "localhost:9001")
-MINIO_ACCESS_KEY = os.getenv("MINIO_ACCESS_KEY", "minioadmin")
-MINIO_SECRET_KEY = os.getenv("MINIO_SECRET_KEY", "minioadmin")
-MINIO_BUCKET = os.getenv("MINIO_BUCKET", "images")
-MINIO_SECURE = os.getenv("MINIO_SECURE", "false").lower() == "true"
-
-minio_client = Minio(
-    MINIO_ENDPOINT,
-    access_key=MINIO_ACCESS_KEY,
-    secret_key=MINIO_SECRET_KEY,
-    secure=MINIO_SECURE,
-)
-
-clip_model = SentenceTransformer("clip-ViT-B-32")
-ocr_reader = easyocr.Reader(["en"], gpu=False)
-
+from .controllers import api_router
+from .core.clients import minio_client
+from .core.config import CORS_ORIGINS, MINIO_BUCKET
+from .core.security import pwd_context
+from .db import Base, SessionLocal, engine
+from .models import User
 
 app = FastAPI()
 
-# Configure CORS
 app.add_middleware(
     CORSMiddleware,
-    allow_origins=[
-        "http://localhost:9000",
-        "http://localhost:4200",
-        "http://localhost:4201",
-        "http://localhost:8080",
-    ],
+    allow_origins=CORS_ORIGINS,
     allow_credentials=True,
     allow_methods=["*"],
     allow_headers=["*"],
 )
 
-pwd_context = CryptContext(schemes=["argon2"], deprecated="auto")
-
-oauth2_scheme = OAuth2PasswordBearer(tokenUrl="/api/login")
+app.include_router(api_router)
 
 
 @app.on_event("startup")
-def on_startup():
+def on_startup() -> None:
+    """Initialise database schema, seed default data and ensure storage."""
+
     Base.metadata.create_all(bind=engine)
     with engine.begin() as connection:
         inspector = inspect(connection)
@@ -94,163 +44,17 @@ def on_startup():
             connection.execute(
                 sa_text("ALTER TABLE images ADD COLUMN text_embedding vector(512)")
             )
+
     db = SessionLocal()
-    if not db.query(User).filter(User.username == "user").first():
-        db.add(User(username="user", hashed_password=pwd_context.hash("password")))
-        db.commit()
-    db.close()
+    try:
+        if not db.query(User).filter(User.username == "user").first():
+            db.add(User(username="user", hashed_password=pwd_context.hash("password")))
+            db.commit()
+    finally:
+        db.close()
+
     if not minio_client.bucket_exists(MINIO_BUCKET):
         minio_client.make_bucket(MINIO_BUCKET)
 
 
-@app.get("/api/hello")
-async def read_hello():
-    return {"message": "Hello from FastAPI"}
-
-
-def authenticate_user(db: Session, username: str, password: str):
-    user = db.query(User).filter(User.username == username).first()
-    if not user:
-        return None
-    if not pwd_context.verify(password, user.hashed_password):
-        return None
-    return user
-
-
-def create_access_token(data: dict, expires_delta: Optional[timedelta] = None):
-    to_encode = data.copy()
-    expire = datetime.utcnow() + (expires_delta or timedelta(minutes=15))
-    to_encode.update({"exp": expire})
-    return jwt.encode(to_encode, JWT_SECRET, algorithm=ALGORITHM)
-
-
-@app.post("/api/login", response_model=Token)
-async def login(
-    form_data: OAuth2PasswordRequestForm = Depends(),
-    db: Session = Depends(get_db),
-):
-    user = authenticate_user(db, form_data.username, form_data.password)
-    if not user:
-        raise HTTPException(status_code=400, detail="Incorrect username or password")
-    access_token = create_access_token(
-        data={"sub": user.username},
-        expires_delta=timedelta(minutes=ACCESS_TOKEN_EXPIRE_MINUTES),
-    )
-    return {"access_token": access_token, "token_type": "bearer"}
-
-
-@app.get("/api/protected")
-async def protected_route(token: str = Depends(oauth2_scheme)):
-    try:
-        payload = jwt.decode(token, JWT_SECRET, algorithms=[ALGORITHM])
-        username: str = payload.get("sub")
-        if username is None:
-            raise HTTPException(status_code=401, detail="Invalid token")
-    except JWTError:
-        raise HTTPException(status_code=401, detail="Invalid token")
-    return {"message": f"Hello, {username}"}
-
-
-@app.post("/api/embeddings/demo", response_model=EmbeddingOut)
-def create_demo_embedding(db: Session = Depends(get_db)):
-    vector = [0.1, 0.2, 0.3]
-    embedding = Embedding(embedding=vector, content="demo content")
-    db.add(embedding)
-    db.commit()
-    db.refresh(embedding)
-    return {"id": embedding.id, "embedding": list(embedding.embedding), "content": embedding.content}
-
-
-@app.get("/api/embeddings/demo", response_model=List[EmbeddingOut])
-def list_embeddings(
-    vector: List[float] = Query(...), db: Session = Depends(get_db)
-):
-    results = (
-        db.query(Embedding)
-        .order_by(Embedding.embedding.cosine_distance(vector))
-        .all()
-    )
-    return [
-        {"id": e.id, "embedding": list(e.embedding), "content": e.content}
-        for e in results
-    ]
-
-
-@app.post("/api/upload-image", response_model=ImageOut)
-async def upload_image(
-    file: UploadFile = File(...), db: Session = Depends(get_db)
-):
-    data = await file.read()
-    object_name = f"{uuid.uuid4()}_{file.filename}"
-    minio_client.put_object(
-        MINIO_BUCKET,
-        object_name,
-        BytesIO(data),
-        length=len(data),
-        content_type=file.content_type,
-    )
-    image = Image.open(BytesIO(data)).convert("RGB")
-    width, height = image.size
-    hash_value = hashlib.sha256(data).hexdigest()
-    url = f"{'https' if MINIO_SECURE else 'http'}://{MINIO_ENDPOINT}/{MINIO_BUCKET}/{object_name}"
-    image_embedding_vector = (
-        clip_model.encode([image], convert_to_tensor=False)[0].tolist()
-    )
-    ocr_text = None
-    text_embedding_vector = None
-    try:
-        ocr_results = ocr_reader.readtext(np.array(image), detail=0)
-        text_parts = [result for result in ocr_results if result]
-        if text_parts:
-            ocr_text = " ".join(text_parts).strip()
-    except Exception:
-        ocr_text = None
-    if ocr_text:
-        text_embedding_vector = (
-            clip_model.encode([ocr_text], convert_to_tensor=False)[0].tolist()
-        )
-    metadata = ImageMetadata(
-        url=url,
-        hash=hash_value,
-        width=width,
-        height=height,
-        embedding=image_embedding_vector,
-        text=ocr_text,
-        text_embedding=text_embedding_vector,
-    )
-    db.add(metadata)
-    db.commit()
-    db.refresh(metadata)
-    image_out = ImageOut(
-        id=metadata.id,
-        url=metadata.url,
-        hash=metadata.hash,
-        width=metadata.width,
-        height=metadata.height,
-        embedding=list(metadata.embedding) if metadata.embedding is not None else [],
-        text=metadata.text,
-        text_embedding=(
-            list(metadata.text_embedding)
-            if metadata.text_embedding is not None
-            else None
-        ),
-    )
-    return image_out
-
-
-@app.post("/api/openai")
-def call_openai(request: OpenAIRequest):
-    api_key = os.getenv("OPENAI_API_KEY")
-    if not api_key:
-        raise HTTPException(status_code=500, detail="OPENAI_API_KEY not set")
-    headers = {
-        "Authorization": f"Bearer {api_key}",
-        "Content-Type": "application/json",
-    }
-    payload = {"model": request.model, "input": request.input}
-    response = requests.post(
-        "https://api.openai.com/v1/responses", headers=headers, json=payload
-    )
-    if response.status_code != 200:
-        raise HTTPException(status_code=response.status_code, detail=response.text)
-    return response.json()
+__all__ = ["app"]

--- a/python-backend/app/models/__init__.py
+++ b/python-backend/app/models/__init__.py
@@ -1,0 +1,7 @@
+"""Database models for the FastAPI application."""
+
+from .embedding import Embedding
+from .image import ImageMetadata
+from .user import User
+
+__all__ = ["Embedding", "ImageMetadata", "User"]

--- a/python-backend/app/models/embedding.py
+++ b/python-backend/app/models/embedding.py
@@ -1,0 +1,16 @@
+"""Embedding model definition."""
+
+from sqlalchemy import Column, Integer, String
+from pgvector.sqlalchemy import Vector
+
+from ..db import Base
+
+
+class Embedding(Base):
+    """Stores vector embeddings linked to optional content."""
+
+    __tablename__ = "embeddings"
+
+    id = Column(Integer, primary_key=True, index=True)
+    content = Column(String, nullable=True)
+    embedding = Column(Vector(3))

--- a/python-backend/app/models/image.py
+++ b/python-backend/app/models/image.py
@@ -1,25 +1,14 @@
+"""Image metadata model definition."""
+
 from sqlalchemy import Column, Integer, String
 from pgvector.sqlalchemy import Vector
-from .db import Base
 
-
-class User(Base):
-    __tablename__ = "users"
-
-    id = Column(Integer, primary_key=True, index=True)
-    username = Column(String, unique=True, index=True)
-    hashed_password = Column(String)
-
-
-class Embedding(Base):
-    __tablename__ = "embeddings"
-
-    id = Column(Integer, primary_key=True, index=True)
-    content = Column(String, nullable=True)
-    embedding = Column(Vector(3))
+from ..db import Base
 
 
 class ImageMetadata(Base):
+    """Stores metadata and embeddings for uploaded images."""
+
     __tablename__ = "images"
 
     id = Column(Integer, primary_key=True, index=True)

--- a/python-backend/app/models/user.py
+++ b/python-backend/app/models/user.py
@@ -1,0 +1,15 @@
+"""User model definition."""
+
+from sqlalchemy import Column, Integer, String
+
+from ..db import Base
+
+
+class User(Base):
+    """Represents an authenticated user."""
+
+    __tablename__ = "users"
+
+    id = Column(Integer, primary_key=True, index=True)
+    username = Column(String, unique=True, index=True)
+    hashed_password = Column(String)

--- a/python-backend/app/views/__init__.py
+++ b/python-backend/app/views/__init__.py
@@ -1,0 +1,30 @@
+"""Public exports for API schemas and helpers."""
+
+from .schemas import (
+    AskRequest,
+    AskResponse,
+    EmbeddingOut,
+    ImageOut,
+    OpenAIRequest,
+    Token,
+    TokenData,
+    UserBase,
+    UserCreate,
+    UserOut,
+)
+from .transformers import embedding_to_out, image_to_out
+
+__all__ = [
+    "AskRequest",
+    "AskResponse",
+    "EmbeddingOut",
+    "ImageOut",
+    "OpenAIRequest",
+    "Token",
+    "TokenData",
+    "UserBase",
+    "UserCreate",
+    "UserOut",
+    "embedding_to_out",
+    "image_to_out",
+]

--- a/python-backend/app/views/schemas.py
+++ b/python-backend/app/views/schemas.py
@@ -1,4 +1,6 @@
-from typing import List
+"""Pydantic schemas for serialising API responses and requests."""
+
+from typing import List, Optional
 
 from pydantic import BaseModel
 
@@ -9,7 +11,7 @@ class Token(BaseModel):
 
 
 class TokenData(BaseModel):
-    username: str | None = None
+    username: Optional[str] = None
 
 
 class UserBase(BaseModel):
@@ -30,8 +32,7 @@ class UserOut(UserBase):
 class EmbeddingOut(BaseModel):
     id: int
     embedding: List[float]
-    content: str | None = None
-
+    content: Optional[str] = None
 
     class Config:
         orm_mode = True
@@ -57,9 +58,8 @@ class ImageOut(BaseModel):
     width: int
     height: int
     embedding: List[float]
-    text: str | None = None
-    text_embedding: List[float] | None = None
+    text: Optional[str] = None
+    text_embedding: Optional[List[float]] = None
 
     class Config:
         orm_mode = True
-

--- a/python-backend/app/views/transformers.py
+++ b/python-backend/app/views/transformers.py
@@ -1,0 +1,31 @@
+"""Helpers for translating database models into API schemas."""
+
+from ..models import Embedding, ImageMetadata
+from .schemas import EmbeddingOut, ImageOut
+
+
+def embedding_to_out(entity: Embedding) -> EmbeddingOut:
+    """Convert an :class:`Embedding` instance into its API representation."""
+
+    return EmbeddingOut(
+        id=entity.id,
+        embedding=list(entity.embedding) if entity.embedding is not None else [],
+        content=entity.content,
+    )
+
+
+def image_to_out(entity: ImageMetadata) -> ImageOut:
+    """Convert an :class:`ImageMetadata` instance into its API representation."""
+
+    return ImageOut(
+        id=entity.id,
+        url=entity.url,
+        hash=entity.hash,
+        width=entity.width,
+        height=entity.height,
+        embedding=list(entity.embedding) if entity.embedding is not None else [],
+        text=entity.text,
+        text_embedding=(
+            list(entity.text_embedding) if entity.text_embedding is not None else None
+        ),
+    )


### PR DESCRIPTION
## Summary
- restructure the FastAPI backend into controllers, models, and views packages to align with MVC conventions
- extract shared configuration, security, and external client setup into dedicated core modules
- simplify the FastAPI entry point to register routers and perform startup initialisation against the new modules

## Testing
- python -m compileall app

------
https://chatgpt.com/codex/tasks/task_e_68c9caa346dc8331811fb49bf13a145f